### PR TITLE
Constant names should comply with a naming convention

### DIFF
--- a/app/src/main/java/me/anany/weikandian/model/BillboardData.java
+++ b/app/src/main/java/me/anany/weikandian/model/BillboardData.java
@@ -22,7 +22,7 @@ public class BillboardData {
      * device_type : 2 【 meybe means Android】
      * phone_code : 186xxxxxx
      * phone_newwork : WIFI/3G/4G
-     * Phone_sim : 1 / 2 / 3  【1 meybe means China Mobile】
+     * Phone_sim : 1 / 2 / 3  【1 meybe means China MOBILE】
      * uid : 9279697
      * uuid : 13cb971cfd30403dbc80314d4216e6ad
      * sign : 31a8f2e3b1c71932245178cf33367042

--- a/app/src/main/java/me/anany/weikandian/model/DiscoverKnowledge.java
+++ b/app/src/main/java/me/anany/weikandian/model/DiscoverKnowledge.java
@@ -23,7 +23,7 @@ public class DiscoverKnowledge {
      * openuidi : 7f08bcd287cc5096
      * os_api : 22
      * os_version : 5.1.1
-     * phone_sim : 1 / 2 / 3  【1 meybe means China Mobile】
+     * phone_sim : 1 / 2 / 3  【1 meybe means China MOBILE】
      * request_time : current request time
      * uid : 9279697
      * uuid : phone IMIE

--- a/app/src/main/java/me/anany/weikandian/model/DiscoverLife.java
+++ b/app/src/main/java/me/anany/weikandian/model/DiscoverLife.java
@@ -23,7 +23,7 @@ public class DiscoverLife {
      * openuidi : 7f08bcd287cc5096
      * os_api : 22
      * os_version : 5.1.1
-     * phone_sim : 1 / 2 / 3  【1 meybe means China Mobile】
+     * phone_sim : 1 / 2 / 3  【1 meybe means China MOBILE】
      * request_time : current request time
      * uid : 9279697
      * uuid : phone IMIE

--- a/app/src/main/java/me/anany/weikandian/model/DiscoverTopNews.java
+++ b/app/src/main/java/me/anany/weikandian/model/DiscoverTopNews.java
@@ -21,7 +21,7 @@ public class DiscoverTopNews {
      * device_type : 2 【 meybe means Android】
      * phone_code : 186xxxxxx
      * phone_newwork : WIFI/3G/4G
-     * Phone_sim : 1 / 2 / 3  【1 meybe means China Mobile】
+     * Phone_sim : 1 / 2 / 3  【1 meybe means China MOBILE】
      * uid : 9279697
      * uuid : 13cb971cfd30403dbc80314d4216e6ad
      * sign : 31a8f2e3b1c71932245178cf33367042

--- a/app/src/main/java/me/anany/weikandian/model/HomeNewsData.java
+++ b/app/src/main/java/me/anany/weikandian/model/HomeNewsData.java
@@ -25,7 +25,7 @@ public class HomeNewsData implements Serializable{
      * openuidi : 7f08bcd287cc5096
      * os_api : 22
      * os_version : 5.1.1
-     * phone_sim : 1 / 2 / 3  【1 meybe means China Mobile】
+     * phone_sim : 1 / 2 / 3  【1 meybe means China MOBILE】
      * request_time : current request time
      * uid : 9279697
      * uuid : phone IMIE

--- a/app/src/main/java/me/anany/weikandian/utils/NetworkUtil.java
+++ b/app/src/main/java/me/anany/weikandian/utils/NetworkUtil.java
@@ -32,10 +32,10 @@ public class NetworkUtil {
     }
     //
     //public enum NetSubType {
-    //    None(1),
-    //    Mobile(2),
-    //    Wifi(4),
-    //    Other(8);
+    //    NONE(1),
+    //    MOBILE(2),
+    //    WIFI(4),
+    //    OTHER(8);
     //
     //    NetType(int value) {
     //        this.value = value;
@@ -76,14 +76,14 @@ public class NetworkUtil {
         if (net != null) {
             switch (net.getType()) {
                 case ConnectivityManager.TYPE_WIFI:
-                    return NetType.Wifi;
+                    return NetType.WIFI;
                 case ConnectivityManager.TYPE_MOBILE:
-                    return NetType.Mobile;
+                    return NetType.MOBILE;
                 default:
-                    return NetType.Other;
+                    return NetType.OTHER;
             }
         }
-        return NetType.None;
+        return NetType.NONE;
     }
 
     /**
@@ -232,7 +232,7 @@ public class NetworkUtil {
     /**
      * GPRS    2G(2.5) General Packet Radia Service 114kbps
      * EDGE    2G(2.75G) Enhanced Data Rate for GSM Evolution 384kbps
-     * UMTS    3G WCDMA 联通3G Universal Mobile Telecommunication System 完整的3G移动通信技术标准
+     * UMTS    3G WCDMA 联通3G Universal MOBILE Telecommunication System 完整的3G移动通信技术标准
      * CDMA    2G 电信 Code Division Multiple Access 码分多址
      * EVDO_0  3G (EVDO 全程 CDMA2000 1xEV-DO) Evolution - Data Only (Data Optimized) 153.6kps - 2.4mbps 属于3G
      * EVDO_A  3G 1.8mbps - 3.1mbps 属于3G过渡，3.5G
@@ -252,7 +252,7 @@ public class NetworkUtil {
         int type = getConnectedTypeINT(context);
         switch (type) {
             case ConnectivityManager.TYPE_WIFI:
-                return NetWorkType.Wifi;
+                return NetWorkType.WIFI;
             case ConnectivityManager.TYPE_MOBILE:
             case ConnectivityManager.TYPE_MOBILE_DUN:
             case ConnectivityManager.TYPE_MOBILE_HIPRI:
@@ -265,7 +265,7 @@ public class NetworkUtil {
                     case TelephonyManager.NETWORK_TYPE_CDMA:
                     case TelephonyManager.NETWORK_TYPE_1xRTT:
                     case TelephonyManager.NETWORK_TYPE_IDEN:
-                        return NetWorkType.Net2G;
+                        return NetWorkType.NET_2_G;
                     case TelephonyManager.NETWORK_TYPE_UMTS:
                     case TelephonyManager.NETWORK_TYPE_EVDO_0:
                     case TelephonyManager.NETWORK_TYPE_EVDO_A:
@@ -275,22 +275,22 @@ public class NetworkUtil {
                     case TelephonyManager.NETWORK_TYPE_EVDO_B:
                     case TelephonyManager.NETWORK_TYPE_EHRPD:
                     case TelephonyManager.NETWORK_TYPE_HSPAP:
-                        return NetWorkType.Net3G;
+                        return NetWorkType.NET_3_G;
                     case TelephonyManager.NETWORK_TYPE_LTE:
-                        return NetWorkType.Net4G;
+                        return NetWorkType.NET_4_G;
                     default:
-                        return NetWorkType.UnKnown;
+                        return NetWorkType.UN_KNOWN;
                 }
             default:
-                return NetWorkType.UnKnown;
+                return NetWorkType.UN_KNOWN;
         }
     }
 
     public enum NetType {
-        None(1),
-        Mobile(2),
-        Wifi(4),
-        Other(8);
+        NONE(1),
+        MOBILE(2),
+        WIFI(4),
+        OTHER(8);
 
         public int value;
 
@@ -300,11 +300,11 @@ public class NetworkUtil {
     }
 
     public enum NetWorkType {
-        UnKnown(-1),
-        Wifi(1),
-        Net2G(2),
-        Net3G(3),
-        Net4G(4);
+        UN_KNOWN(-1),
+        WIFI(1),
+        NET_2_G(2),
+        NET_3_G(3),
+        NET_4_G(4);
 
         public int value;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00115 - “Constant names should comply with a naming convention”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
Ayman Abdelghany.
