### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/MyDaoGenerator/src/main/java/pl/surecase/eu/MyDaoGenerator.java
+++ b/MyDaoGenerator/src/main/java/pl/surecase/eu/MyDaoGenerator.java
@@ -6,6 +6,9 @@ import de.greenrobot.daogenerator.Schema;
 
 public class MyDaoGenerator {
 
+    private MyDaoGenerator() {
+    }
+
     public static void main(String args[]) throws Exception {
         Schema schema = new Schema( 1, "me.anany.bean");
         // 1: 数据库版本号

--- a/app/src/main/java-gen/me/anany/dao/DaoUtil.java
+++ b/app/src/main/java-gen/me/anany/dao/DaoUtil.java
@@ -16,6 +16,9 @@ import me.anany.weikandian.utils.LogUtil;
  */
 public class DaoUtil {
 
+    private DaoUtil() {
+    }
+
     public static String getHomeItemInput_time(Context mContext, int position) {
 
         String input_time = "";

--- a/app/src/main/java-gen/me/anany/dao/HomeChannelDBDao.java
+++ b/app/src/main/java-gen/me/anany/dao/HomeChannelDBDao.java
@@ -29,6 +29,9 @@ public class HomeChannelDBDao extends AbstractDao<HomeChannelDB, Long> {
         public final static Property Name = new Property(3, String.class, "name", false, "NAME");
         public final static Property Pic = new Property(4, String.class, "pic", false, "PIC");
         public final static Property Sname = new Property(5, String.class, "sname", false, "SNAME");
+
+        private Properties() {
+        }
     };
 
 

--- a/app/src/main/java-gen/me/anany/dao/HomeItemDBDao.java
+++ b/app/src/main/java-gen/me/anany/dao/HomeItemDBDao.java
@@ -50,6 +50,9 @@ public class HomeItemDBDao extends AbstractDao<HomeItemDB, Long> {
         public final static Property Article_type = new Property(24, String.class, "article_type", false, "ARTICLE_TYPE");
         public final static Property Behot_time = new Property(25, String.class, "behot_time", false, "BEHOT_TIME");
         public final static Property ExtraImg = new Property(26, String.class, "extraImg", false, "EXTRA_IMG");
+
+        private Properties() {
+        }
     };
 
 

--- a/app/src/main/java-gen/me/anany/dao/HomeTitleDBDao.java
+++ b/app/src/main/java-gen/me/anany/dao/HomeTitleDBDao.java
@@ -32,6 +32,9 @@ public class HomeTitleDBDao extends AbstractDao<HomeTitleDB, Long> {
         public final static Property Description = new Property(6, String.class, "description", false, "DESCRIPTION");
         public final static Property Is_new = new Property(7, String.class, "is_new", false, "IS_NEW");
         public final static Property Is_use = new Property(8, String.class, "is_use", false, "IS_USE");
+
+        private Properties() {
+        }
     };
 
 

--- a/app/src/main/java/me/anany/weikandian/utils/NetworkUtil.java
+++ b/app/src/main/java/me/anany/weikandian/utils/NetworkUtil.java
@@ -17,6 +17,9 @@ public class NetworkUtil {
 
     private static final String TAG = NetworkUtil.class.getSimpleName();
 
+    private NetworkUtil() {
+    }
+
     /**
      * 获取ConnectivityManager
      */

--- a/app/src/main/java/me/anany/weikandian/utils/SpUtil.java
+++ b/app/src/main/java/me/anany/weikandian/utils/SpUtil.java
@@ -12,6 +12,9 @@ import android.preference.PreferenceManager;
 public class SpUtil {
 
 
+    private SpUtil() {
+    }
+
     public static String getPrefString(Context context, String key,
                                        final String defaultValue) {
         final SharedPreferences settings = PreferenceManager

--- a/app/src/main/java/me/anany/weikandian/utils/UiUtil.java
+++ b/app/src/main/java/me/anany/weikandian/utils/UiUtil.java
@@ -9,6 +9,9 @@ import android.content.Context;
  */
 public class UiUtil {
 
+    private UiUtil() {
+    }
+
     /**
      * dip转为 px
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
