### PR TITLE
Array designators "[]" should be on the type, not the variable

### DIFF
--- a/MyDaoGenerator/src/main/java/pl/surecase/eu/MyDaoGenerator.java
+++ b/MyDaoGenerator/src/main/java/pl/surecase/eu/MyDaoGenerator.java
@@ -6,7 +6,7 @@ import de.greenrobot.daogenerator.Schema;
 
 public class MyDaoGenerator {
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         Schema schema = new Schema( 1, "me.anany.bean");
         // 1: 数据库版本号
         // com.xxx.bean:自动生成的Bean对象会放到/java-gen/com/xxx/bean中

--- a/app/src/main/java/me/anany/weikandian/ui/activity/MainActivity.java
+++ b/app/src/main/java/me/anany/weikandian/ui/activity/MainActivity.java
@@ -30,23 +30,23 @@ public class MainActivity extends BaseActivity implements OnTabChangeListener {
     private LayoutInflater layoutInflater;
 
     //定义数组来存放Fragment界面
-    private Class fragmentArray[] = { HomeFragment.class, MineFragment.class,
-            SubscribeFragment.class, DiscoverFragment.class, BillboardFragment.class };
+    private Class[] fragmentArray = {HomeFragment.class, MineFragment.class,
+            SubscribeFragment.class, DiscoverFragment.class, BillboardFragment.class};
 
     //定义数组来存放按钮图片
-    private int mImageViewArray[] = { R.drawable.tab_home_btn, R.drawable.tab_subscribe_btn,
+    private int[] mImageViewArray = {R.drawable.tab_home_btn, R.drawable.tab_subscribe_btn,
             R.drawable.tab_billboard_btn,
             R.drawable.tab_discover_btn,
-            R.drawable.tab_mine_btn };
+            R.drawable.tab_mine_btn};
 
     //定义数组来存放文字颜色
-    private int mTextColorArray[] = { R.drawable.tab_home_text_color, R.drawable.tab_subscribe_text_color,
+    private int[] mTextColorArray = {R.drawable.tab_home_text_color, R.drawable.tab_subscribe_text_color,
             R.drawable.tab_billboard_text_color,
             R.drawable.tab_discover_text_color,
-            R.drawable.tab_mine_text_color };
+            R.drawable.tab_mine_text_color};
 
     //Tab选项卡的文字
-    private String mTextViewArray[] = { "首页", "订阅", "排行榜", "发现", "我的" };
+    private String[] mTextViewArray = {"首页", "订阅", "排行榜", "发现", "我的"};
 
     @Override
     protected int inflateLayoutId() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - “Array designators "[]" should be on the type, not the variable”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
Ayman Abdelghany.
